### PR TITLE
Abstract Data Storage away from Metric objects, and introduce Swappable Data Stores

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ before_install:
   - |
     if [[ "$(ruby -e 'puts RUBY_VERSION')" != 1.* ]]; then gem update --system; fi
 rvm:
-  - 1.9.3
   - 2.3.3
   - 2.4.0
   - jruby-9.1.5.0

--- a/README.md
+++ b/README.md
@@ -158,15 +158,18 @@ histogram.get(labels: { service: 'users' })
 Summary, similar to histograms, is an accumulator for samples. It captures
 Numeric data and provides an efficient percentile calculation mechanism.
 
+For now, only `sum` and `total` (count of observations) are supported, no actual quantiles.
+
 ```ruby
 summary = Prometheus::Client::Summary.new(:service_latency_seconds, docstring: '...', labels: [:service])
 
 # record a value
 summary.observe(Benchmark.realtime { service.call() }, labels: { service: 'database' })
 
-# retrieve the current quantile values
-summary.get(labels: { service: 'database' })
-# => { 0.5 => 0.1233122, 0.9 => 3.4323, 0.99 => 5.3428231 }
+# retrieve the current sum and total values
+summary_value = summary.get(labels: { service: 'database' })
+summary_value.sum # => 123.45
+summary_value.count # => 100
 ```
 
 ## Labels

--- a/README.md
+++ b/README.md
@@ -19,12 +19,12 @@ require 'prometheus/client'
 prometheus = Prometheus::Client.registry
 
 # create a new counter metric
-http_requests = Prometheus::Client::Counter.new(:http_requests, 'A counter of HTTP requests made')
+http_requests = Prometheus::Client::Counter.new(:http_requests, docstring: 'A counter of HTTP requests made')
 # register the metric
 prometheus.register(http_requests)
 
 # equivalent helper function
-http_requests = prometheus.counter(:http_requests, 'A counter of HTTP requests made')
+http_requests = prometheus.counter(:http_requests, docstring: 'A counter of HTTP requests made')
 
 # start using the counter
 http_requests.increment
@@ -99,16 +99,16 @@ The following metric types are currently supported.
 Counter is a metric that exposes merely a sum or tally of things.
 
 ```ruby
-counter = Prometheus::Client::Counter.new(:service_requests_total, '...')
+counter = Prometheus::Client::Counter.new(:service_requests_total, docstring: '...')
 
 # increment the counter for a given label set
-counter.increment({ service: 'foo' })
+counter.increment(labels: { service: 'foo' })
 
 # increment by a given value
-counter.increment({ service: 'bar' }, 5)
+counter.increment(by: 5, labels: { service: 'bar' })
 
 # get current value for a given label set
-counter.get({ service: 'bar' })
+counter.get(labels: { service: 'bar' })
 # => 5
 ```
 
@@ -118,21 +118,21 @@ Gauge is a metric that exposes merely an instantaneous value or some snapshot
 thereof.
 
 ```ruby
-gauge = Prometheus::Client::Gauge.new(:room_temperature_celsius, '...')
+gauge = Prometheus::Client::Gauge.new(:room_temperature_celsius, docstring: '...')
 
 # set a value
-gauge.set({ room: 'kitchen' }, 21.534)
+gauge.set(21.534, labels: { room: 'kitchen' })
 
 # retrieve the current value for a given label set
-gauge.get({ room: 'kitchen' })
+gauge.get(labels: { room: 'kitchen' })
 # => 21.534
 
 # increment the value (default is 1)
-gauge.increment({ room: 'kitchen' })
+gauge.increment(labels: { room: 'kitchen' })
 # => 22.534
 
 # decrement the value by a given value
-gauge.decrement({ room: 'kitchen' }, 5)
+gauge.decrement(by: 5, labels: { room: 'kitchen' })
 # => 17.534
 ```
 
@@ -143,13 +143,13 @@ response sizes) and counts them in configurable buckets. It also provides a sum
 of all observed values.
 
 ```ruby
-histogram = Prometheus::Client::Histogram.new(:service_latency_seconds, '...')
+histogram = Prometheus::Client::Histogram.new(:service_latency_seconds, docstring: '...')
 
 # record a value
-histogram.observe({ service: 'users' }, Benchmark.realtime { service.call(arg) })
+histogram.observe(Benchmark.realtime { service.call(arg) }, labels: { service: 'users' })
 
 # retrieve the current bucket values
-histogram.get({ service: 'users' })
+histogram.get(labels: { service: 'users' })
 # => { 0.005 => 3, 0.01 => 15, 0.025 => 18, ..., 2.5 => 42, 5 => 42, 10 = >42 }
 ```
 
@@ -159,13 +159,13 @@ Summary, similar to histograms, is an accumulator for samples. It captures
 Numeric data and provides an efficient percentile calculation mechanism.
 
 ```ruby
-summary = Prometheus::Client::Summary.new(:service_latency_seconds, '...')
+summary = Prometheus::Client::Summary.new(:service_latency_seconds, docstring: '...')
 
 # record a value
-summary.observe({ service: 'database' }, Benchmark.realtime { service.call() })
+summary.observe(Benchmark.realtime { service.call() }, labels: { service: 'database' })
 
 # retrieve the current quantile values
-summary.get({ service: 'database' })
+summary.get(labels: { service: 'database' })
 # => { 0.5 => 0.1233122, 0.9 => 3.4323, 0.99 => 5.3428231 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -214,7 +214,47 @@ https_requests_total = Counter.new(:http_requests_total,
 https_requests_total.increment(labels: { status_code: response.status_code })
 ```
 
+### `with_labels`
 
+Similar to pre-setting labels, you can get a new instance of an existing metric object,
+with a subset (or full set) of labels set, so that you can increment / observe the metric
+without having to specify the labels for every call.
+
+Moreover, if all the labels the metric can take have been pre-set, validation of the labels
+is done on the call to `with_labels`, and then skipped for each observation, which can 
+lead to performance improvements. If you are incrementing a counter in a fast loop, you
+definitely want to be doing this.
+
+
+Examples:
+
+**Pre-setting labels for ease of use:**
+
+```ruby
+# in the file where you define your metrics:
+records_processed_total = registry.counter.new(:records_processed_total, 
+                                               docstring: '...', 
+                                               labels: [:service, :component],
+                                               preset_labels: { service: "my_service" })
+
+# in one-off calls, you'd specify the missing labels (component in this case)
+records_processed_total.increment(labels: { component: 'a_component' })
+
+# you can also have a "view" on this metric for a specific component where this label is
+# pre-set:
+class MyComponent
+  def metric
+    @metric ||= records_processed_total.with_labels(component: "my_component")
+  end
+  
+  def process
+    records.each do |record|
+      # process the record
+      metric.increment 
+    end
+  end
+end
+```
 
 ## Tests
 

--- a/examples/rack/README.md
+++ b/examples/rack/README.md
@@ -49,6 +49,8 @@ something like this:
 
 ```ruby
 use Prometheus::Middleware::Collector, counter_label_builder: ->(env, code) {
+  next { code: nil, method: nil, host: nil, path: nil } if env.empty?
+
   {
     code:         code,
     method:       env['REQUEST_METHOD'].downcase,

--- a/lib/prometheus/client.rb
+++ b/lib/prometheus/client.rb
@@ -1,6 +1,7 @@
 # encoding: UTF-8
 
 require 'prometheus/client/registry'
+require 'prometheus/client/config'
 
 module Prometheus
   # Client is a ruby implementation for a Prometheus compatible client.
@@ -8,6 +9,10 @@ module Prometheus
     # Returns a default registry object
     def self.registry
       @registry ||= Registry.new
+    end
+
+    def self.config
+      @config ||= Config.new
     end
   end
 end

--- a/lib/prometheus/client/config.rb
+++ b/lib/prometheus/client/config.rb
@@ -1,0 +1,15 @@
+# encoding: UTF-8
+
+require 'prometheus/client/data_stores/simple_hash'
+
+module Prometheus
+  module Client
+    class Config
+      attr_accessor :data_store
+
+      def initialize
+        @data_store = Prometheus::Client::DataStores::SimpleHash.new
+      end
+    end
+  end
+end

--- a/lib/prometheus/client/counter.rb
+++ b/lib/prometheus/client/counter.rb
@@ -10,7 +10,7 @@ module Prometheus
         :counter
       end
 
-      def increment(labels = {}, by = 1)
+      def increment(by: 1, labels: {})
         raise ArgumentError, 'increment must be a non-negative number' if by < 0
 
         label_set = label_set_for(labels)

--- a/lib/prometheus/client/counter.rb
+++ b/lib/prometheus/client/counter.rb
@@ -14,13 +14,7 @@ module Prometheus
         raise ArgumentError, 'increment must be a non-negative number' if by < 0
 
         label_set = label_set_for(labels)
-        synchronize { @values[label_set] += by }
-      end
-
-      private
-
-      def default
-        0.0
+        @store.increment(labels: label_set, by: by)
       end
     end
   end

--- a/lib/prometheus/client/data_stores/README.md
+++ b/lib/prometheus/client/data_stores/README.md
@@ -1,0 +1,260 @@
+# Custom Data Stores
+
+Stores are basically an abstraction over a Hash, whose keys are in turn a Hash of labels
+plus a metric name. The intention behind having different data stores is solving 
+different requirements for different production scenarios, or performance trade-offs.
+
+The most common of these scenarios are pre-fork servers like Unicorn, which have multiple
+separate processes gathering metrics. If each of these had their own store, the metrics
+reported on each Prometheus scrape would be different, depending on which process handles
+the request. Solving this requires some sort of shared storage between these processes, 
+and there are many ways to solve this problem, each with their own trade-offs.
+
+This abstraction allows us to easily plug in the most adequate store for each scenario.
+
+## Interface
+   
+`Store` exposes a `for_metric` method, which returns a store-specific and metric-specific 
+`MetricStore` object, which represents a "view" onto the actual internal storage for one
+particular metric. Each metric / collector object will have a references to this 
+`MetricStore` and interact with it directly. 
+
+The `MetricStore` class must expose `synchronize`, `set`, `increment`, `get` and `all_values`
+methods,  which are explained in the code sample below. Its initializer should be called 
+only by `Store#for_metric`, not directly.
+
+All values stored are `Float`s.
+
+Internally, a `Store` can store the data however it needs to, based on its requirements. 
+For example, a store that needs to work in a multi-process environment needs to have a 
+shared section of memory, via either Files, an MMap, an external database, or whatever the 
+implementor chooses for their particular use case.
+
+Each `Store` / `MetricStore` will also choose how to divide responsibilities over the 
+storage of values. For some use cases, each `MetricStore` may have their own individual 
+storage, whereas for others, the `Store` may own a central storage, and `MetricStore` 
+objects will access it through the `Store`. This depends on the design choices of each `Store`. 
+
+`Store` and `MetricStore` MUST be thread safe. This applies not only to operations on 
+stored values (`set`, `increment`), but `MetricStore` must also expose a `synchronize`
+method that would allow a Metric to increment multiple values atomically (Histograms need
+this, for example).
+
+Ideally, multiple keys should be modifiable simultaneously, but this is not a
+hard requirement.
+
+This is what the interface looks like, in practice:
+
+```ruby
+module Prometheus
+  module Client
+    module DataStores
+      class CustomStore
+      
+        # Return a MetricStore, which provides a view of the internal data store, 
+        # catering specifically to that metric.
+        #
+        # - `metric_settings` specifies configuration parameters for this metric 
+        #   specifically. These may or may not be necessary, depending on each specific
+        #   store and metric. The most obvious example of this is for gauges in 
+        #   multi-process environments, where the developer needs to choose how those 
+        #   gauges will get aggregated between all the per-process values.
+        # 
+        #   The settings that the store will accept, and what it will do with them, are
+        #   100% Store-specific. Each store should document what settings it will accept
+        #   and how to use them, so the developer using that store can pass the appropriate 
+        #   instantiating the Store itself, and the Metrics they declare.
+        #
+        # - `metric_type` is specified in case a store wants to validate that the settings
+        #   are valid for the metric being set up. It may go unused by most Stores
+        #
+        # Even if your store doesn't need these two parameters, the Store must expose them
+        # to make them swappable.   
+        def for_metric(metric_name, metric_type:, metric_settings: {})
+          # Generally, here a Store would validate that the settings passed in are valid,
+          # and raise if they aren't.
+          validate_metric_settings(metric_type: metric_type, 
+                                   metric_settings: metric_settings)
+          MetricStore.new(store: self, 
+                          metric_name: metric_name, 
+                          metric_type: metric_type, 
+                          metric_settings: metric_settings)
+        end
+
+        
+        # MetricStore manages the data for one specific metric. It's generally a view onto
+        # the central store shared by all metrics, but it could also hold the data itself
+        # if that's better for the specific scenario 
+        class MetricStore
+          # This constructor is internal to this store, so the signature doesn't need to
+          # be this. No one other than the Store should be creating MetricStores 
+          def initialize(store:, metric_name:, metric_type:, metric_settings:)
+          end
+
+          # Metrics may need to modify multiple values at once (Histograms do this, for 
+          # example). MetricStore needs to provide a way to synchronize those, in addition
+          # to all of the value modifications being thread-safe without a need for simple 
+          # Metrics to call `synchronize`
+          def synchronize
+            raise NotImplementedError
+          end
+
+
+          # Store a value for this metric and a set of labels
+          # Internally, may add extra "labels" to disambiguate values between,
+          # for example, different processes
+          def set(labels:, val:)
+            raise NotImplementedError
+          end
+
+          def increment(labels:, by: 1)
+            raise NotImplementedError
+          end
+  
+          # Return a value for a set of labels
+          # Will return the same value stored by `set`, as opposed to `all_values`, which 
+          # may aggregate multiple values.
+          #
+          # For example, in a multi-process scenario, `set` may add an extra internal
+          # label tagging the value with the process id. `get` will return the value for
+          # "this" process ID. `all_values` will return an aggregated value for all 
+          # process IDs.
+          def get(labels:)
+            raise NotImplementedError
+          end
+  
+          # Returns all the sets of labels seen by the Store, and the aggregated value for 
+          # each.
+          # 
+          # In some cases, this is just a matter of returning the stored value.
+          # 
+          # In other cases, the store may need to aggregate multiple values for the same
+          # set of labels. For example, in a multiple process it may need to `sum` the
+          # values of counters from each process. Or for `gauges`, it may need to take the
+          # `max`. This is generally specified in `metric_settings` when calling 
+          # `Store#for_metric`.
+          def all_values
+            raise NotImplementedError
+          end
+        end
+      end
+    end
+  end
+end
+```
+
+
+## Sample, imaginary multi-process Data Store
+
+This is just an example of how one could implement a data store, and a clarification on
+the "aggregation" point 
+
+Important: This is **VAPORWARE**, intended simply to show how this could work / how to
+implement these interfaces.
+
+There are some key pieces of code missing, which are fairly uninteresting, this only shows
+the parts that illustrate the idea of storing multiple different values, and aggregate
+them
+
+```ruby
+module Prometheus
+  module Client
+    module DataStores
+      # Stores all the data in a magic data structure that keeps cross-process data, in a
+      # way that all processes can read it, but each can write only to their own set of
+      # keys.
+      # It doesn't care how that works, this is not an actual solution to anything,
+      # just an example of how the interface would work with something like that.
+      #
+      # Metric Settings have one possible key, `aggregation`, which must be one of
+      # `AGGREGATION_MODES`
+      class SampleMagicMultiprocessStore
+        AGGREGATION_MODES = [MAX = :max, MIN = :min, SUM = :sum, AVG = :avg]
+        DEFAULT_METRIC_SETTINGS = { aggregation: SUM }
+
+        def initialize
+          @internal_store = MagicHashSharedBetweenProcesses.new # PStore, for example
+        end
+
+        def for_metric(metric_name, metric_type:, metric_settings: {})
+          settings = DEFAULT_METRIC_SETTINGS.merge(metric_settings)
+          validate_metric_settings(metric_settings: settings)
+          MetricStore.new(store: self,
+                          metric_name: metric_name,
+                          metric_type: metric_type,
+                          metric_settings: settings)
+        end
+
+        private
+
+        def validate_metric_settings(metric_settings:)
+          raise unless metric_settings.has_key?(:aggregation)
+          raise unless metric_settings[:aggregation].in?(AGGREGATION_MODES)
+        end
+
+        class MetricStore
+          def initialize(store:, metric_name:, metric_type:, metric_settings:)
+            @store = store
+            @internal_store = store.internal_store
+            @metric_name = metric_name
+            @aggregation_mode = metric_settings[:aggregation]
+          end
+
+          def set(labels:, val:)
+            @internal_store[store_key(labels)] = val.to_f
+          end
+
+          def get(labels:)
+            @internal_store[store_key(labels)]
+          end
+
+          def all_values
+            non_aggregated_values = all_store_values.each_with_object({}) do |(labels, v), acc|
+              if labels["__metric_name"] == @metric_name
+                label_set = labels.reject { |k,_| k.in?("__metric_name", "__pid") }
+                acc[label_set] ||= []
+                acc[label_set] << v
+              end
+            end
+
+            # Aggregate all the different values for each label_set
+            non_aggregated_values.each_with_object({}) do |(label_set, values), acc|
+              acc[label_set] = aggregate(values)
+            end
+          end
+
+          private
+
+          def all_store_values
+            # This assumes there's a something common that all processes can write to, and
+            # it's magically synchronized (which is not true of a PStore, for example, but
+            # would of some sort of external data store like Redis, Memcached, SQLite)
+
+            # This could also have some sort of:
+            #    file_list = Dir.glob(File.join(path, '*.db')).sort
+            # which reads all the PStore files / MMapped files, etc, and returns a hash
+            # with all of them together, which then `values` and `label_sets` can use
+          end
+
+          # This method holds most of the key to how this Store works. Adding `_pid` as
+          # one of the labels, we hold each process's value separately, which we can 
+          # aggregate later 
+          def store_key(labels)
+            labels.merge(
+              {
+                "__metric_name" => @metric_name,
+                "__pid" => Process.pid
+              }
+            )
+          end
+
+          def aggregate(values)
+            # This is a horrible way to do this, just illustrating the point
+            values.send(@aggregation_mode)
+          end
+        end
+      end
+    end
+  end
+end
+```

--- a/lib/prometheus/client/data_stores/simple_hash.rb
+++ b/lib/prometheus/client/data_stores/simple_hash.rb
@@ -1,0 +1,91 @@
+require 'concurrent'
+
+module Prometheus
+  module Client
+    module DataStores
+      # Stores all the data in a simple, synchronized global Hash
+      #
+      # There are ways of making this faster (because of the naive Mutex usage).
+      class SimpleHash
+        class InvalidStoreSettingsError < StandardError; end
+
+        attr_reader :internal_store
+
+        def initialize
+          @internal_store = Hash.new { |hash, key| hash[key] = 0.0 }
+          @rwlock = Concurrent::ReentrantReadWriteLock.new
+        end
+
+        def for_metric(metric_name, metric_type:, metric_settings: {})
+          # We don't need `metric_type` or `metric_settings` for this particular store
+          validate_metric_settings(metric_settings: metric_settings)
+          MetricStore.new(store: self, metric_name: metric_name)
+        end
+
+        def synchronize
+          @rwlock.with_write_lock { yield }
+        end
+
+        private
+
+        def validate_metric_settings(metric_settings:)
+          unless metric_settings.empty?
+            raise InvalidStoreSettingsError,
+                  "SimpleHash doesn't allow any metric_settings"
+          end
+        end
+
+        class MetricStore
+          def initialize(store:, metric_name:)
+            @store = store
+            @internal_store = store.internal_store
+            @metric_name = metric_name
+          end
+
+          def synchronize
+            @store.synchronize { yield }
+          end
+
+          def set(labels:, val:)
+            synchronize do
+              @internal_store[store_key(labels)] = val.to_f
+            end
+          end
+
+          def increment(labels:, by: 1)
+            synchronize do
+              @internal_store[store_key(labels)] += by
+            end
+          end
+
+          def get(labels:)
+            synchronize do
+              @internal_store[store_key(labels)]
+            end
+          end
+
+          def all_values
+            store_copy = synchronize { @internal_store.dup }
+
+            store_copy.each_with_object({}) do |(labels, v), acc|
+              if labels["__metric_name"] == @metric_name
+                label_set = labels.reject { |k,_| k == "__metric_name" }
+                acc[label_set] = v
+              end
+            end
+          end
+
+          private
+
+          def store_key(labels)
+            labels.merge(
+              { "__metric_name" => @metric_name }
+            )
+          end
+        end
+
+        private_constant :MetricStore
+      end
+    end
+  end
+end

--- a/lib/prometheus/client/formats/text.rb
+++ b/lib/prometheus/client/formats/text.rb
@@ -51,20 +51,20 @@ module Prometheus
 
           def summary(name, set, value)
             l = labels(set)
-            yield metric("#{name}_sum", l, value.sum)
-            yield metric("#{name}_count", l, value.total)
+            yield metric("#{name}_sum", l, value["sum"])
+            yield metric("#{name}_count", l, value["count"])
           end
 
           def histogram(name, set, value)
             bucket = "#{name}_bucket"
             value.each do |q, v|
+              next if q == "sum"
               yield metric(bucket, labels(set.merge(le: q)), v)
             end
-            yield metric(bucket, labels(set.merge(le: '+Inf')), value.total)
 
             l = labels(set)
-            yield metric("#{name}_sum", l, value.sum)
-            yield metric("#{name}_count", l, value.total)
+            yield metric("#{name}_sum", l, value["sum"])
+            yield metric("#{name}_count", l, value["+Inf"])
           end
 
           def metric(name, labels, value)

--- a/lib/prometheus/client/formats/text.rb
+++ b/lib/prometheus/client/formats/text.rb
@@ -40,14 +40,12 @@ module Prometheus
           private
 
           def representation(metric, label_set, value, &block)
-            set = metric.base_labels.merge(label_set)
-
             if metric.type == :summary
-              summary(metric.name, set, value, &block)
+              summary(metric.name, label_set, value, &block)
             elsif metric.type == :histogram
-              histogram(metric.name, set, value, &block)
+              histogram(metric.name, label_set, value, &block)
             else
-              yield metric(metric.name, labels(set), value)
+              yield metric(metric.name, labels(label_set), value)
             end
           end
 

--- a/lib/prometheus/client/formats/text.rb
+++ b/lib/prometheus/client/formats/text.rb
@@ -50,10 +50,6 @@ module Prometheus
           end
 
           def summary(name, set, value)
-            value.each do |q, v|
-              yield metric(name, labels(set.merge(quantile: q)), v)
-            end
-
             l = labels(set)
             yield metric("#{name}_sum", l, value.sum)
             yield metric("#{name}_count", l, value.total)

--- a/lib/prometheus/client/gauge.rb
+++ b/lib/prometheus/client/gauge.rb
@@ -17,27 +17,21 @@ module Prometheus
           raise ArgumentError, 'value must be a number'
         end
 
-        @values[label_set_for(labels)] = value.to_f
+        @store.set(labels: label_set_for(labels), val: value)
       end
 
       # Increments Gauge value by 1 or adds the given value to the Gauge.
       # (The value can be negative, resulting in a decrease of the Gauge.)
       def increment(by: 1, labels: {})
         label_set = label_set_for(labels)
-        synchronize do
-          @values[label_set] ||= 0
-          @values[label_set] += by
-        end
+        @store.increment(labels: label_set, by: by)
       end
 
       # Decrements Gauge value by 1 or subtracts the given value from the Gauge.
       # (The value can be negative, resulting in a increase of the Gauge.)
       def decrement(by: 1, labels: {})
         label_set = label_set_for(labels)
-        synchronize do
-          @values[label_set] ||= 0
-          @values[label_set] -= by
-        end
+        @store.increment(labels: label_set, by: -by)
       end
     end
   end

--- a/lib/prometheus/client/gauge.rb
+++ b/lib/prometheus/client/gauge.rb
@@ -12,7 +12,7 @@ module Prometheus
       end
 
       # Sets the value for the given label set
-      def set(labels, value)
+      def set(value, labels: {})
         unless value.is_a?(Numeric)
           raise ArgumentError, 'value must be a number'
         end
@@ -22,7 +22,7 @@ module Prometheus
 
       # Increments Gauge value by 1 or adds the given value to the Gauge.
       # (The value can be negative, resulting in a decrease of the Gauge.)
-      def increment(labels = {}, by = 1)
+      def increment(by: 1, labels: {})
         label_set = label_set_for(labels)
         synchronize do
           @values[label_set] ||= 0
@@ -32,7 +32,7 @@ module Prometheus
 
       # Decrements Gauge value by 1 or subtracts the given value from the Gauge.
       # (The value can be negative, resulting in a increase of the Gauge.)
-      def decrement(labels = {}, by = 1)
+      def decrement(by: 1, labels: {})
         label_set = label_set_for(labels)
         synchronize do
           @values[label_set] ||= 0

--- a/lib/prometheus/client/histogram.rb
+++ b/lib/prometheus/client/histogram.rb
@@ -8,48 +8,29 @@ module Prometheus
     # or response sizes) and counts them in configurable buckets. It also
     # provides a sum of all observed values.
     class Histogram < Metric
-      # Value represents the state of a Histogram at a given point.
-      class Value < Hash
-        attr_accessor :sum, :total
-
-        def initialize(buckets:)
-          @sum = 0.0
-          @total = 0.0
-
-          buckets.each do |bucket|
-            self[bucket] = 0.0
-          end
-        end
-
-        def observe(value)
-          @sum += value
-          @total += 1
-
-          each_key do |bucket|
-            self[bucket] += 1 if value <= bucket
-          end
-        end
-      end
-
       # DEFAULT_BUCKETS are the default Histogram buckets. The default buckets
       # are tailored to broadly measure the response time (in seconds) of a
       # network service. (From DefBuckets client_golang)
       DEFAULT_BUCKETS = [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1,
                          2.5, 5, 10].freeze
 
+      attr_reader :buckets
+
       # Offer a way to manually specify buckets
       def initialize(name,
                      docstring:,
                      labels: [],
                      preset_labels: {},
-                     buckets: DEFAULT_BUCKETS)
-        raise ArgumentError, 'Unsorted buckets, typo?' unless sorted? buckets
+                     buckets: DEFAULT_BUCKETS,
+                     store_settings: {})
+        raise ArgumentError, 'Unsorted buckets, typo?' unless sorted?(buckets)
 
         @buckets = buckets
         super(name,
               docstring: docstring,
               labels: labels,
-              preset_labels: preset_labels)
+              preset_labels: preset_labels,
+              store_settings: store_settings)
       end
 
       def type
@@ -57,18 +38,48 @@ module Prometheus
       end
 
       def observe(value, labels: {})
-        label_set = label_set_for(labels)
-        synchronize { @values[label_set].observe(value) }
+        base_label_set = label_set_for(labels)
+
+        @store.synchronize do
+          buckets.each do |upper_limit|
+            next if value > upper_limit
+            @store.increment(labels: base_label_set.merge(le: upper_limit), by: 1)
+          end
+          @store.increment(labels: base_label_set.merge(le: "+Inf"), by: 1)
+          @store.increment(labels: base_label_set.merge(le: "sum"), by: value)
+        end
+      end
+
+      # Returns a hash with all the buckets plus +Inf (count) plus Sum for the given label set
+      def get(labels: {})
+        base_label_set = label_set_for(labels)
+
+        all_buckets = buckets + ["+Inf", "sum"]
+
+        @store.synchronize do
+          all_buckets.each_with_object({}) do |upper_limit, acc|
+            acc[upper_limit] = @store.get(labels: base_label_set.merge(le: upper_limit))
+          end.tap do |acc|
+            acc["count"] = acc["+Inf"]
+          end
+        end
+      end
+
+      # Returns all label sets with their values expressed as hashes with their buckets
+      def values
+        v = @store.all_values
+
+        v.each_with_object({}) do |(label_set, v), acc|
+          actual_label_set = label_set.reject{|l| l == :le }
+          acc[actual_label_set] ||= @buckets.map{|b| [b, 0.0]}.to_h
+          acc[actual_label_set][label_set[:le]] = v
+        end
       end
 
       private
 
       def reserved_labels
         [:le]
-      end
-
-      def default
-        Value.new(buckets: @buckets)
       end
 
       def sorted?(bucket)

--- a/lib/prometheus/client/histogram.rb
+++ b/lib/prometheus/client/histogram.rb
@@ -38,11 +38,18 @@ module Prometheus
                          2.5, 5, 10].freeze
 
       # Offer a way to manually specify buckets
-      def initialize(name, docstring:, base_labels: {}, buckets: DEFAULT_BUCKETS)
+      def initialize(name,
+                     docstring:,
+                     labels: [],
+                     preset_labels: {},
+                     buckets: DEFAULT_BUCKETS)
         raise ArgumentError, 'Unsorted buckets, typo?' unless sorted? buckets
 
         @buckets = buckets
-        super(name, docstring: docstring, base_labels: base_labels)
+        super(name,
+              docstring: docstring,
+              labels: labels,
+              preset_labels: preset_labels)
       end
 
       def type
@@ -50,15 +57,15 @@ module Prometheus
       end
 
       def observe(value, labels: {})
-        if labels[:le]
-          raise ArgumentError, 'Label with name "le" is not permitted'
-        end
-
         label_set = label_set_for(labels)
         synchronize { @values[label_set].observe(value) }
       end
 
       private
+
+      def reserved_labels
+        [:le]
+      end
 
       def default
         Value.new(buckets: @buckets)

--- a/lib/prometheus/client/histogram.rb
+++ b/lib/prometheus/client/histogram.rb
@@ -12,7 +12,7 @@ module Prometheus
       class Value < Hash
         attr_accessor :sum, :total
 
-        def initialize(buckets)
+        def initialize(buckets:)
           @sum = 0.0
           @total = 0.0
 
@@ -38,19 +38,18 @@ module Prometheus
                          2.5, 5, 10].freeze
 
       # Offer a way to manually specify buckets
-      def initialize(name, docstring, base_labels = {},
-                     buckets = DEFAULT_BUCKETS)
+      def initialize(name, docstring:, base_labels: {}, buckets: DEFAULT_BUCKETS)
         raise ArgumentError, 'Unsorted buckets, typo?' unless sorted? buckets
 
         @buckets = buckets
-        super(name, docstring, base_labels)
+        super(name, docstring: docstring, base_labels: base_labels)
       end
 
       def type
         :histogram
       end
 
-      def observe(labels, value)
+      def observe(value, labels: {})
         if labels[:le]
           raise ArgumentError, 'Label with name "le" is not permitted'
         end
@@ -62,7 +61,7 @@ module Prometheus
       private
 
       def default
-        Value.new(@buckets)
+        Value.new(buckets: @buckets)
       end
 
       def sorted?(bucket)

--- a/lib/prometheus/client/histogram.rb
+++ b/lib/prometheus/client/histogram.rb
@@ -33,6 +33,15 @@ module Prometheus
               store_settings: store_settings)
       end
 
+      def with_labels(labels)
+        self.class.new(name,
+                       docstring: docstring,
+                       labels: expected_labels,
+                       preset_labels: preset_labels.merge(labels),
+                       buckets: @buckets,
+                       store_settings: @store_settings)
+      end
+
       def type
         :histogram
       end

--- a/lib/prometheus/client/label_set_validator.rb
+++ b/lib/prometheus/client/label_set_validator.rb
@@ -21,7 +21,7 @@ module Prometheus
         @validated = {}
       end
 
-      def valid?(labels)
+      def validate_symbols!(labels)
         unless labels.respond_to?(:all?)
           raise InvalidLabelSetError, "#{labels} is not a valid label set"
         end
@@ -33,24 +33,24 @@ module Prometheus
         end
       end
 
-      def validate(labels)
-        return labels if @validated.key?(labels.hash)
+      def validate_labelset!(labelset)
+        return labelset if @validated.key?(labelset.hash)
 
-        valid?(labels)
+        validate_symbols!(labelset)
 
-        unless keys_match?(labels)
+        unless keys_match?(labelset)
           raise InvalidLabelSetError, "labels must have the same signature " \
-                                      "(keys given: #{labels.keys.sort} vs." \
+                                      "(keys given: #{labelset.keys.sort} vs." \
                                       " keys expected: #{expected_labels}"
         end
 
-        @validated[labels.hash] = labels
+        @validated[labelset.hash] = labelset
       end
 
       private
 
-      def keys_match?(labels)
-        labels.keys.sort == expected_labels
+      def keys_match?(labelset)
+        labelset.keys.sort == expected_labels
       end
 
       def validate_symbol(key)

--- a/lib/prometheus/client/metric.rb
+++ b/lib/prometheus/client/metric.rb
@@ -34,6 +34,11 @@ module Prometheus
           metric_type: type,
           metric_settings: store_settings
         )
+
+        if preset_labels.keys.length == labels.length
+          @validator.validate(preset_labels)
+          @all_labels_preset = true
+        end
       end
 
       # Returns the value for the given label set
@@ -78,6 +83,8 @@ module Prometheus
       end
 
       def label_set_for(labels)
+        # We've already validated, and there's nothing to merge. Save some cycles
+        return preset_labels if @all_labels_preset && labels.empty?
         @validator.validate(preset_labels.merge(labels))
       end
     end

--- a/lib/prometheus/client/metric.rb
+++ b/lib/prometheus/client/metric.rb
@@ -22,6 +22,9 @@ module Prometheus
         @validator.valid?(labels)
         @validator.valid?(preset_labels)
 
+        @labels = labels
+        @store_settings = store_settings
+
         @name = name
         @docstring = docstring
         @preset_labels = preset_labels
@@ -37,6 +40,14 @@ module Prometheus
       def get(labels: {})
         label_set = label_set_for(labels)
         @store.get(labels: label_set)
+      end
+
+      def with_labels(labels)
+        self.class.new(name,
+                       docstring: docstring,
+                       labels: @labels,
+                       preset_labels: preset_labels.merge(labels),
+                       store_settings: @store_settings)
       end
 
       # Returns all label sets with their values

--- a/lib/prometheus/client/metric.rb
+++ b/lib/prometheus/client/metric.rb
@@ -19,8 +19,8 @@ module Prometheus
         validate_docstring(docstring)
         @validator = LabelSetValidator.new(expected_labels: labels,
                                            reserved_labels: reserved_labels)
-        @validator.valid?(labels)
-        @validator.valid?(preset_labels)
+        @validator.validate_symbols!(labels)
+        @validator.validate_symbols!(preset_labels)
 
         @labels = labels
         @store_settings = store_settings
@@ -36,7 +36,7 @@ module Prometheus
         )
 
         if preset_labels.keys.length == labels.length
-          @validator.validate(preset_labels)
+          @validator.validate_labelset!(preset_labels)
           @all_labels_preset = true
         end
       end
@@ -85,7 +85,7 @@ module Prometheus
       def label_set_for(labels)
         # We've already validated, and there's nothing to merge. Save some cycles
         return preset_labels if @all_labels_preset && labels.empty?
-        @validator.validate(preset_labels.merge(labels))
+        @validator.validate_labelset!(preset_labels.merge(labels))
       end
     end
   end

--- a/lib/prometheus/client/metric.rb
+++ b/lib/prometheus/client/metric.rb
@@ -9,7 +9,7 @@ module Prometheus
     class Metric
       attr_reader :name, :docstring, :base_labels
 
-      def initialize(name, docstring, base_labels = {})
+      def initialize(name, docstring:, base_labels: {})
         @mutex = Mutex.new
         @validator = LabelSetValidator.new
         @values = Hash.new { |hash, key| hash[key] = default }
@@ -24,7 +24,7 @@ module Prometheus
       end
 
       # Returns the value for the given label set
-      def get(labels = {})
+      def get(labels: {})
         @validator.valid?(labels)
 
         @values[labels]

--- a/lib/prometheus/client/registry.rb
+++ b/lib/prometheus/client/registry.rb
@@ -37,21 +37,24 @@ module Prometheus
         end
       end
 
-      def counter(name, docstring, base_labels = {})
-        register(Counter.new(name, docstring, base_labels))
+      def counter(name, docstring:, base_labels: {})
+        register(Counter.new(name, docstring: docstring, base_labels: base_labels))
       end
 
-      def summary(name, docstring, base_labels = {})
-        register(Summary.new(name, docstring, base_labels))
+      def summary(name, docstring:, base_labels: {})
+        register(Summary.new(name, docstring: docstring, base_labels: base_labels))
       end
 
-      def gauge(name, docstring, base_labels = {})
-        register(Gauge.new(name, docstring, base_labels))
+      def gauge(name, docstring:, base_labels: {})
+        register(Gauge.new(name, docstring: docstring, base_labels: base_labels))
       end
 
-      def histogram(name, docstring, base_labels = {},
-                    buckets = Histogram::DEFAULT_BUCKETS)
-        register(Histogram.new(name, docstring, base_labels, buckets))
+      def histogram(name, docstring:, base_labels: {},
+                    buckets: Histogram::DEFAULT_BUCKETS)
+        register(Histogram.new(name,
+                               docstring: docstring,
+                               base_labels: base_labels,
+                               buckets: buckets))
       end
 
       def exist?(name)

--- a/lib/prometheus/client/registry.rb
+++ b/lib/prometheus/client/registry.rb
@@ -37,23 +37,33 @@ module Prometheus
         end
       end
 
-      def counter(name, docstring:, base_labels: {})
-        register(Counter.new(name, docstring: docstring, base_labels: base_labels))
+      def counter(name, docstring:, labels: [], preset_labels: {})
+        register(Counter.new(name,
+                             docstring: docstring,
+                             labels: labels,
+                             preset_labels: preset_labels))
       end
 
-      def summary(name, docstring:, base_labels: {})
-        register(Summary.new(name, docstring: docstring, base_labels: base_labels))
+      def summary(name, docstring:, labels: [], preset_labels: {})
+        register(Summary.new(name,
+                             docstring: docstring,
+                             labels: labels,
+                             preset_labels: preset_labels))
       end
 
-      def gauge(name, docstring:, base_labels: {})
-        register(Gauge.new(name, docstring: docstring, base_labels: base_labels))
+      def gauge(name, docstring:, labels: [], preset_labels: {})
+        register(Gauge.new(name,
+                           docstring: docstring,
+                           labels: labels,
+                           preset_labels: preset_labels))
       end
 
-      def histogram(name, docstring:, base_labels: {},
+      def histogram(name, docstring:, labels: [], preset_labels: {},
                     buckets: Histogram::DEFAULT_BUCKETS)
         register(Histogram.new(name,
                                docstring: docstring,
-                               base_labels: base_labels,
+                               labels: labels,
+                               preset_labels: preset_labels,
                                buckets: buckets))
       end
 

--- a/lib/prometheus/client/registry.rb
+++ b/lib/prometheus/client/registry.rb
@@ -37,34 +37,39 @@ module Prometheus
         end
       end
 
-      def counter(name, docstring:, labels: [], preset_labels: {})
+      def counter(name, docstring:, labels: [], preset_labels: {}, store_settings: {})
         register(Counter.new(name,
                              docstring: docstring,
                              labels: labels,
-                             preset_labels: preset_labels))
+                             preset_labels: preset_labels,
+                             store_settings: {}))
       end
 
-      def summary(name, docstring:, labels: [], preset_labels: {})
+      def summary(name, docstring:, labels: [], preset_labels: {}, store_settings: {})
         register(Summary.new(name,
                              docstring: docstring,
                              labels: labels,
-                             preset_labels: preset_labels))
+                             preset_labels: preset_labels,
+                             store_settings: {}))
       end
 
-      def gauge(name, docstring:, labels: [], preset_labels: {})
+      def gauge(name, docstring:, labels: [], preset_labels: {}, store_settings: {})
         register(Gauge.new(name,
                            docstring: docstring,
                            labels: labels,
-                           preset_labels: preset_labels))
+                           preset_labels: preset_labels,
+                           store_settings: {}))
       end
 
       def histogram(name, docstring:, labels: [], preset_labels: {},
-                    buckets: Histogram::DEFAULT_BUCKETS)
+                    buckets: Histogram::DEFAULT_BUCKETS,
+                    store_settings: {})
         register(Histogram.new(name,
                                docstring: docstring,
                                labels: labels,
                                preset_labels: preset_labels,
-                               buckets: buckets))
+                               buckets: buckets,
+                               store_settings: {}))
       end
 
       def exist?(name)

--- a/lib/prometheus/client/summary.rb
+++ b/lib/prometheus/client/summary.rb
@@ -52,6 +52,10 @@ module Prometheus
 
       private
 
+      def reserved_labels
+        [:quantile]
+      end
+
       def default
         Quantile::Estimator.new
       end

--- a/lib/prometheus/client/summary.rb
+++ b/lib/prometheus/client/summary.rb
@@ -12,7 +12,7 @@ module Prometheus
       class Value < Hash
         attr_accessor :sum, :total
 
-        def initialize(estimator)
+        def initialize(estimator:)
           @sum = estimator.sum
           @total = estimator.observations
 
@@ -27,17 +27,17 @@ module Prometheus
       end
 
       # Records a given value.
-      def observe(labels, value)
+      def observe(value, labels: {})
         label_set = label_set_for(labels)
         synchronize { @values[label_set].observe(value) }
       end
 
       # Returns the value for the given label set
-      def get(labels = {})
+      def get(labels: {})
         @validator.valid?(labels)
 
         synchronize do
-          Value.new(@values[labels])
+          Value.new(estimator: @values[labels])
         end
       end
 
@@ -45,7 +45,7 @@ module Prometheus
       def values
         synchronize do
           @values.each_with_object({}) do |(labels, value), memo|
-            memo[labels] = Value.new(value)
+            memo[labels] = Value.new(estimator: value)
           end
         end
       end

--- a/lib/prometheus/client/summary.rb
+++ b/lib/prometheus/client/summary.rb
@@ -8,8 +8,6 @@ module Prometheus
     # Summary is an accumulator for samples. It captures Numeric data and
     # provides an efficient quantile calculation mechanism.
     class Summary < Metric
-      extend Gem::Deprecate
-
       # Value represents the state of a Summary at a given point.
       class Value < Hash
         attr_accessor :sum, :total
@@ -33,8 +31,6 @@ module Prometheus
         label_set = label_set_for(labels)
         synchronize { @values[label_set].observe(value) }
       end
-      alias add observe
-      deprecate :add, :observe, 2016, 10
 
       # Returns the value for the given label set
       def get(labels = {})

--- a/lib/prometheus/client/summary.rb
+++ b/lib/prometheus/client/summary.rb
@@ -7,39 +7,48 @@ module Prometheus
     # Summary is an accumulator for samples. It captures Numeric data and
     # provides the total count and sum of observations.
     class Summary < Metric
-      # Value represents the state of a Summary at a given point.
-      class Value
-        attr_accessor :sum, :total
-
-        def initialize
-          @sum = 0.0
-          @total = 0.0
-        end
-
-        def observe(value)
-          @sum += value
-          @total += 1
-        end
-      end
-
       def type
         :summary
       end
 
       # Records a given value.
       def observe(value, labels: {})
-        label_set = label_set_for(labels)
-        synchronize { @values[label_set].observe(value) }
+        base_label_set = label_set_for(labels)
+
+        @store.synchronize do
+          @store.increment(labels: base_label_set.merge(quantile: "count"), by: 1)
+          @store.increment(labels: base_label_set.merge(quantile: "sum"), by: value)
+        end
+      end
+
+      # Returns a hash with "sum" and "count" as keys
+      def get(labels: {})
+        base_label_set = label_set_for(labels)
+
+        internal_counters = ["count", "sum"]
+
+        @store.synchronize do
+          internal_counters.each_with_object({}) do |counter, acc|
+            acc[counter] = @store.get(labels: base_label_set.merge(quantile: counter))
+          end
+        end
+      end
+
+      # Returns all label sets with their values expressed as hashes with their sum/count
+      def values
+        v = @store.all_values
+
+        v.each_with_object({}) do |(label_set, v), acc|
+          actual_label_set = label_set.reject{|l| l == :quantile }
+          acc[actual_label_set] ||= { "count" => 0.0, "sum" => 0.0 }
+          acc[actual_label_set][label_set[:quantile]] = v
+        end
       end
 
       private
 
       def reserved_labels
         [:quantile]
-      end
-
-      def default
-        Value.new
       end
     end
   end

--- a/lib/prometheus/middleware/collector.rb
+++ b/lib/prometheus/middleware/collector.rb
@@ -20,6 +20,11 @@ module Prometheus
     #
     # The request duration metric is broken down by method and path by default.
     # Set the `:duration_label_builder` option to use a custom label builder.
+    #
+    # Label Builder functions will receive a Rack env and a status code, and must
+    # return a hash with the labels for that request. They must also accept an empty
+    # env, and return a hash with the correct keys. This is necessary to initialize
+    # the metrics with the correct set of labels.
     class Collector
       attr_reader :app, :registry
 
@@ -47,6 +52,8 @@ module Prometheus
       end
 
       COUNTER_LB = proc do |env, code|
+        next { code: nil, method: nil, path: nil } if env.empty?
+
         {
           code:   code,
           method: env['REQUEST_METHOD'].downcase,
@@ -55,6 +62,8 @@ module Prometheus
       end
 
       DURATION_LB = proc do |env, _|
+        next { method: nil, path: nil } if env.empty?
+
         {
           method: env['REQUEST_METHOD'].downcase,
           path:   aggregation.call(env['PATH_INFO']),
@@ -66,10 +75,12 @@ module Prometheus
           :"#{@metrics_prefix}_requests_total",
           docstring:
             'The total number of HTTP requests handled by the Rack application.',
+          labels: @counter_lb.call({}, "").keys
         )
         @durations = @registry.histogram(
           :"#{@metrics_prefix}_request_duration_seconds",
           docstring: 'The HTTP response duration of the Rack application.',
+          labels: @duration_lb.call({}, "").keys
         )
       end
 
@@ -77,6 +88,7 @@ module Prometheus
         @exceptions = @registry.counter(
           :"#{@metrics_prefix}_exceptions_total",
           docstring: 'The total number of exceptions raised by the Rack application.',
+          labels: [:exception]
         )
       end
 

--- a/prometheus-client.gemspec
+++ b/prometheus-client.gemspec
@@ -14,4 +14,6 @@ Gem::Specification.new do |s|
 
   s.files             = %w(README.md) + Dir.glob('{lib/**/*}')
   s.require_paths     = ['lib']
+
+  s.add_dependency 'concurrent-ruby'
 end

--- a/prometheus-client.gemspec
+++ b/prometheus-client.gemspec
@@ -14,6 +14,4 @@ Gem::Specification.new do |s|
 
   s.files             = %w(README.md) + Dir.glob('{lib/**/*}')
   s.require_paths     = ['lib']
-
-  s.add_dependency 'quantile', '~> 0.2.1'
 end

--- a/spec/examples/data_store_example.rb
+++ b/spec/examples/data_store_example.rb
@@ -1,0 +1,50 @@
+# encoding: UTF-8
+
+shared_examples_for Prometheus::Client::DataStores do
+  describe "MetricStore#set and #get" do
+    it "returns the value set for each labelset" do
+      metric_store.set(labels: { foo: "bar" }, val: 5)
+      metric_store.set(labels: { foo: "baz" }, val: 2)
+      expect(metric_store.get(labels: { foo: "bar" })).to eq(5)
+      expect(metric_store.get(labels: { foo: "baz" })).to eq(2)
+      expect(metric_store.get(labels: { foo: "bat" })).to eq(0)
+    end
+  end
+
+  describe "MetricStore#increment" do
+    it "returns the value set for each labelset" do
+      metric_store.set(labels: { foo: "bar" }, val: 5)
+      metric_store.set(labels: { foo: "baz" }, val: 2)
+
+      metric_store.increment(labels: { foo: "bar" })
+      metric_store.increment(labels: { foo: "baz" }, by: 7)
+      metric_store.increment(labels: { foo: "zzz" }, by: 3)
+
+      expect(metric_store.get(labels: { foo: "bar" })).to eq(6)
+      expect(metric_store.get(labels: { foo: "baz" })).to eq(9)
+      expect(metric_store.get(labels: { foo: "zzz" })).to eq(3)
+    end
+  end
+
+  describe "MetricStore#synchronize" do
+    # I'm not sure it's possible to actually test that this synchronizes, but at least
+    # it should run the passed block
+    it "accepts a block and runs it" do
+      a = 0
+      metric_store.synchronize{ a += 1 }
+      expect(a).to eq(1)
+    end
+  end
+
+  describe "MetricStore#all_values" do
+    it "returns all specified labelsets, with their associated value" do
+      metric_store.set(labels: { foo: "bar" }, val: 5)
+      metric_store.set(labels: { foo: "baz" }, val: 2)
+
+      expect(metric_store.all_values).to eq(
+        { foo: "bar" } => 5.0,
+        { foo: "baz" } => 2.0,
+      )
+    end
+  end
+end

--- a/spec/examples/metric_example.rb
+++ b/spec/examples/metric_example.rb
@@ -14,7 +14,7 @@ shared_examples_for Prometheus::Client::Metric do
       expect do
         described_class.new(:foo,
                             docstring: 'foo docstring',
-                            base_labels: { __name__: 'reserved' })
+                            preset_labels: { __name__: 'reserved' })
       end.to raise_exception exception
     end
 
@@ -56,8 +56,12 @@ shared_examples_for Prometheus::Client::Metric do
       expect(subject.get).to be_a(type)
     end
 
-    it 'returns the current metric value for a given label set' do
-      expect(subject.get(labels: { test: 'label' })).to be_a(type)
+    context "with a subject that expects labels" do
+      subject { described_class.new(:foo, docstring: 'Labels', labels: [:test]) }
+
+      it 'returns the current metric value for a given label set' do
+        expect(subject.get(labels: { test: 'label' })).to be_a(type)
+      end
     end
   end
 end

--- a/spec/examples/metric_example.rb
+++ b/spec/examples/metric_example.rb
@@ -1,7 +1,7 @@
 # encoding: UTF-8
 
 shared_examples_for Prometheus::Client::Metric do
-  subject { described_class.new(:foo, 'foo description') }
+  subject { described_class.new(:foo, docstring: 'foo description') }
 
   describe '.new' do
     it 'returns a new metric' do
@@ -12,19 +12,21 @@ shared_examples_for Prometheus::Client::Metric do
       exception = Prometheus::Client::LabelSetValidator::ReservedLabelError
 
       expect do
-        described_class.new(:foo, 'foo docstring', __name__: 'reserved')
+        described_class.new(:foo,
+                            docstring: 'foo docstring',
+                            base_labels: { __name__: 'reserved' })
       end.to raise_exception exception
     end
 
     it 'raises an exception if the given name is blank' do
       expect do
-        described_class.new(nil, 'foo')
+        described_class.new(nil, docstring: 'foo')
       end.to raise_exception ArgumentError
     end
 
     it 'raises an exception if docstring is missing' do
       expect do
-        described_class.new(:foo, '')
+        described_class.new(:foo, docstring: '')
       end.to raise_exception ArgumentError
     end
 
@@ -37,7 +39,7 @@ shared_examples_for Prometheus::Client::Metric do
         "abc\ndef".to_sym,
       ].each do |name|
         expect do
-          described_class.new(name, 'foo')
+          described_class.new(name, docstring: 'foo')
         end.to raise_exception(ArgumentError)
       end
     end
@@ -55,7 +57,7 @@ shared_examples_for Prometheus::Client::Metric do
     end
 
     it 'returns the current metric value for a given label set' do
-      expect(subject.get(test: 'label')).to be_a(type)
+      expect(subject.get(labels: { test: 'label' })).to be_a(type)
     end
   end
 end

--- a/spec/prometheus/client/counter_spec.rb
+++ b/spec/prometheus/client/counter_spec.rb
@@ -4,7 +4,9 @@ require 'prometheus/client/counter'
 require 'examples/metric_example'
 
 describe Prometheus::Client::Counter do
-  let(:counter) { Prometheus::Client::Counter.new(:foo, 'foo description') }
+  let(:counter) do
+    Prometheus::Client::Counter.new(:foo, docstring: 'foo description')
+  end
 
   it_behaves_like Prometheus::Client::Metric do
     let(:type) { Float }
@@ -20,20 +22,20 @@ describe Prometheus::Client::Counter do
     it 'increments the counter for a given label set' do
       expect do
         expect do
-          counter.increment(test: 'label')
-        end.to change { counter.get(test: 'label') }.by(1.0)
+          counter.increment(labels: { test: 'label' })
+        end.to change { counter.get(labels: { test: 'label' }) }.by(1.0)
       end.to_not change { counter.get }
     end
 
     it 'increments the counter by a given value' do
       expect do
-        counter.increment({}, 5)
+        counter.increment(by: 5)
       end.to change { counter.get }.by(5.0)
     end
 
     it 'raises an ArgumentError on negative increments' do
       expect do
-        counter.increment({}, -1)
+        counter.increment(by: -1)
       end.to raise_error ArgumentError
     end
 

--- a/spec/prometheus/client/counter_spec.rb
+++ b/spec/prometheus/client/counter_spec.rb
@@ -1,9 +1,15 @@
 # encoding: UTF-8
 
+require 'prometheus/client'
 require 'prometheus/client/counter'
 require 'examples/metric_example'
 
 describe Prometheus::Client::Counter do
+  # Reset the data store
+  before do
+    Prometheus::Client.config.data_store = Prometheus::Client::DataStores::SimpleHash.new
+  end
+
   let(:expected_labels) { [] }
 
   let(:counter) do

--- a/spec/prometheus/client/data_stores/simple_hash_spec.rb
+++ b/spec/prometheus/client/data_stores/simple_hash_spec.rb
@@ -1,0 +1,19 @@
+# encoding: UTF-8
+
+require 'prometheus/client/data_stores/simple_hash'
+require 'examples/data_store_example'
+
+describe Prometheus::Client::DataStores::SimpleHash do
+  subject { described_class.new }
+  let(:metric_store) { subject.for_metric(:metric_name, metric_type: :counter) }
+
+  it_behaves_like Prometheus::Client::DataStores
+
+  it "does not accept Metric Settings" do
+    expect do
+      subject.for_metric(:metric_name,
+                         metric_type: :counter,
+                         metric_settings: { some_setting: true })
+    end.to raise_error(Prometheus::Client::DataStores::SimpleHash::InvalidStoreSettingsError)
+  end
+end

--- a/spec/prometheus/client/formats/text_spec.rb
+++ b/spec/prometheus/client/formats/text_spec.rb
@@ -20,27 +20,24 @@ describe Prometheus::Client::Formats::Text do
       double(
         name: :foo,
         docstring: 'foo description',
-        base_labels: { umlauts: 'Björn', utf: '佖佥' },
         type: :counter,
         values: {
-          { code: 'red' }   => 42.0,
-          { code: 'green' } => 3.14E42,
-          { code: 'blue' }  => -1.23e-45,
+          { umlauts: 'Björn', utf: '佖佥', code: 'red' }   => 42.0,
+          { umlauts: 'Björn', utf: '佖佥', code: 'green' } => 3.14E42,
+          { umlauts: 'Björn', utf: '佖佥', code: 'blue' }  => -1.23e-45,
         },
       ),
       double(
         name: :bar,
         docstring: "bar description\nwith newline",
-        base_labels: { status: 'success' },
         type: :gauge,
         values: {
-          { code: 'pink' } => 15.0,
+          { status: 'success', code: 'pink' } => 15.0,
         },
       ),
       double(
         name: :baz,
         docstring: 'baz "description" \\escaping',
-        base_labels: {},
         type: :counter,
         values: {
           { text: "with \"quotes\", \\escape \n and newline" } => 15.0,
@@ -49,16 +46,14 @@ describe Prometheus::Client::Formats::Text do
       double(
         name: :qux,
         docstring: 'qux description',
-        base_labels: { for: 'sake' },
         type: :summary,
         values: {
-          { code: '1' } => summary_value,
+          { for: 'sake', code: '1' } => summary_value,
         },
       ),
       double(
         name: :xuq,
         docstring: 'xuq description',
-        base_labels: {},
         type: :histogram,
         values: {
           { code: 'ah' } => histogram_value,

--- a/spec/prometheus/client/formats/text_spec.rb
+++ b/spec/prometheus/client/formats/text_spec.rb
@@ -4,9 +4,7 @@ require 'prometheus/client/formats/text'
 
 describe Prometheus::Client::Formats::Text do
   let(:summary_value) do
-    { 0.5 => 4.2, 0.9 => 8.32, 0.99 => 15.3 }.tap do |value|
-      allow(value).to receive_messages(sum: 1243.21, total: 93)
-    end
+    Struct.new(:sum, :total).new(1243.21, 93.0)
   end
 
   let(:histogram_value) do
@@ -79,11 +77,8 @@ bar{status="success",code="pink"} 15.0
 baz{text="with \"quotes\", \\escape \n and newline"} 15.0
 # TYPE qux summary
 # HELP qux qux description
-qux{for="sake",code="1",quantile="0.5"} 4.2
-qux{for="sake",code="1",quantile="0.9"} 8.32
-qux{for="sake",code="1",quantile="0.99"} 15.3
 qux_sum{for="sake",code="1"} 1243.21
-qux_count{for="sake",code="1"} 93
+qux_count{for="sake",code="1"} 93.0
 # TYPE xuq histogram
 # HELP xuq xuq description
 xuq_bucket{code="ah",le="10"} 1.0

--- a/spec/prometheus/client/formats/text_spec.rb
+++ b/spec/prometheus/client/formats/text_spec.rb
@@ -4,13 +4,11 @@ require 'prometheus/client/formats/text'
 
 describe Prometheus::Client::Formats::Text do
   let(:summary_value) do
-    Struct.new(:sum, :total).new(1243.21, 93.0)
+    { "count" => 93.0, "sum" => 1243.21 }
   end
 
   let(:histogram_value) do
-    { 10 => 1.0, 20 => 2.0, 30 => 2.0 }.tap do |value|
-      allow(value).to receive_messages(sum: 15.2, total: 2.0)
-    end
+    { 10 => 1.0, 20 => 2.0, 30 => 2.0, "+Inf" => 2.0, "sum" => 15.2 }
   end
 
   let(:registry) do

--- a/spec/prometheus/client/formats/text_spec.rb
+++ b/spec/prometheus/client/formats/text_spec.rb
@@ -1,62 +1,53 @@
 # encoding: UTF-8
 
+require 'prometheus/client/registry'
 require 'prometheus/client/formats/text'
 
 describe Prometheus::Client::Formats::Text do
-  let(:summary_value) do
-    { "count" => 93.0, "sum" => 1243.21 }
+  # Reset the data store
+  before do
+    Prometheus::Client.config.data_store = Prometheus::Client::DataStores::SimpleHash.new
   end
 
-  let(:histogram_value) do
-    { 10 => 1.0, 20 => 2.0, 30 => 2.0, "+Inf" => 2.0, "sum" => 15.2 }
-  end
+  let(:registry) { Prometheus::Client::Registry.new }
 
-  let(:registry) do
-    metrics = [
-      double(
-        name: :foo,
-        docstring: 'foo description',
-        type: :counter,
-        values: {
-          { umlauts: 'Björn', utf: '佖佥', code: 'red' }   => 42.0,
-          { umlauts: 'Björn', utf: '佖佥', code: 'green' } => 3.14E42,
-          { umlauts: 'Björn', utf: '佖佥', code: 'blue' }  => -1.23e-45,
-        },
-      ),
-      double(
-        name: :bar,
-        docstring: "bar description\nwith newline",
-        type: :gauge,
-        values: {
-          { status: 'success', code: 'pink' } => 15.0,
-        },
-      ),
-      double(
-        name: :baz,
-        docstring: 'baz "description" \\escaping',
-        type: :counter,
-        values: {
-          { text: "with \"quotes\", \\escape \n and newline" } => 15.0,
-        },
-      ),
-      double(
-        name: :qux,
-        docstring: 'qux description',
-        type: :summary,
-        values: {
-          { for: 'sake', code: '1' } => summary_value,
-        },
-      ),
-      double(
-        name: :xuq,
-        docstring: 'xuq description',
-        type: :histogram,
-        values: {
-          { code: 'ah' } => histogram_value,
-        },
-      ),
-    ]
-    double(metrics: metrics)
+  before do
+    foo = registry.counter(:foo,
+                           docstring: 'foo description',
+                           labels: [:umlauts, :utf, :code],
+                           preset_labels: {umlauts: 'Björn', utf: '佖佥'})
+    foo.increment(labels: { code: 'red'}, by: 42)
+    foo.increment(labels: { code: 'green'}, by: 3.14E42)
+    foo.increment(labels: { code: 'blue'}, by: 1.23e-45)
+
+
+    bar = registry.gauge(:bar,
+                         docstring: "bar description\nwith newline",
+                         labels: [:status, :code])
+    bar.set(15, labels: { status: 'success', code: 'pink'})
+
+
+    baz = registry.counter(:baz,
+                           docstring: 'baz "description" \\escaping',
+                           labels: [:text])
+    baz.increment(labels: { text: "with \"quotes\", \\escape \n and newline" }, by: 15.0)
+
+
+    qux = registry.summary(:qux,
+                           docstring: 'qux description',
+                           labels: [:for, :code],
+                           preset_labels: { for: 'sake', code: '1' })
+    92.times { qux.observe(0) }
+    qux.observe(1243.21)
+
+
+    xuq = registry.histogram(:xuq,
+                             docstring: 'xuq description',
+                             labels: [:code],
+                             preset_labels: {code: 'ah'},
+                             buckets: [10, 20, 30])
+    xuq.observe(12)
+    xuq.observe(3.2)
   end
 
   describe '.marshal' do
@@ -66,7 +57,7 @@ describe Prometheus::Client::Formats::Text do
 # HELP foo foo description
 foo{umlauts="Björn",utf="佖佥",code="red"} 42.0
 foo{umlauts="Björn",utf="佖佥",code="green"} 3.14e+42
-foo{umlauts="Björn",utf="佖佥",code="blue"} -1.23e-45
+foo{umlauts="Björn",utf="佖佥",code="blue"} 1.23e-45
 # TYPE bar gauge
 # HELP bar bar description\nwith newline
 bar{status="success",code="pink"} 15.0

--- a/spec/prometheus/client/gauge_spec.rb
+++ b/spec/prometheus/client/gauge_spec.rb
@@ -4,7 +4,7 @@ require 'prometheus/client/gauge'
 require 'examples/metric_example'
 
 describe Prometheus::Client::Gauge do
-  let(:gauge) { Prometheus::Client::Gauge.new(:foo, 'foo description') }
+  let(:gauge) { Prometheus::Client::Gauge.new(:foo, docstring: 'foo description') }
 
   it_behaves_like Prometheus::Client::Metric do
     let(:type) { NilClass }
@@ -13,22 +13,22 @@ describe Prometheus::Client::Gauge do
   describe '#set' do
     it 'sets a metric value' do
       expect do
-        gauge.set({}, 42)
+        gauge.set(42)
       end.to change { gauge.get }.from(nil).to(42)
     end
 
     it 'sets a metric value for a given label set' do
       expect do
         expect do
-          gauge.set({ test: 'value' }, 42)
-        end.to change { gauge.get(test: 'value') }.from(nil).to(42)
+          gauge.set(42, labels: { test: 'value' })
+        end.to change { gauge.get(labels: { test: 'value' }) }.from(nil).to(42)
       end.to_not change { gauge.get }
     end
 
     context 'given an invalid value' do
       it 'raises an ArgumentError' do
         expect do
-          gauge.set({}, nil)
+          gauge.set(nil)
         end.to raise_exception(ArgumentError)
       end
     end
@@ -36,7 +36,7 @@ describe Prometheus::Client::Gauge do
 
   describe '#increment' do
     before do
-      gauge.set(RSpec.current_example.metadata[:labels] || {}, 0)
+      gauge.set(0, labels: RSpec.current_example.metadata[:labels] || {})
     end
 
     it 'increments the gauge' do
@@ -48,14 +48,14 @@ describe Prometheus::Client::Gauge do
     it 'increments the gauge for a given label set', labels: { test: 'one' } do
       expect do
         expect do
-          gauge.increment(test: 'one')
-        end.to change { gauge.get(test: 'one') }.by(1.0)
-      end.to_not change { gauge.get(test: 'another') }
+          gauge.increment(labels: { test: 'one' })
+        end.to change { gauge.get(labels: { test: 'one' }) }.by(1.0)
+      end.to_not change { gauge.get(labels: { test: 'another' }) }
     end
 
     it 'increments the gauge by a given value' do
       expect do
-        gauge.increment({}, 5)
+        gauge.increment(by: 5)
       end.to change { gauge.get }.by(5.0)
     end
 
@@ -76,7 +76,7 @@ describe Prometheus::Client::Gauge do
 
   describe '#decrement' do
     before do
-      gauge.set(RSpec.current_example.metadata[:labels] || {}, 0)
+      gauge.set(0, labels: RSpec.current_example.metadata[:labels] || {})
     end
 
     it 'increments the gauge' do
@@ -88,14 +88,14 @@ describe Prometheus::Client::Gauge do
     it 'decrements the gauge for a given label set', labels: { test: 'one' } do
       expect do
         expect do
-          gauge.decrement(test: 'one')
-        end.to change { gauge.get(test: 'one') }.by(-1.0)
-      end.to_not change { gauge.get(test: 'another') }
+          gauge.decrement(labels: { test: 'one' })
+        end.to change { gauge.get(labels: { test: 'one' }) }.by(-1.0)
+      end.to_not change { gauge.get(labels: { test: 'another' }) }
     end
 
     it 'decrements the gauge by a given value' do
       expect do
-        gauge.decrement({}, 5)
+        gauge.decrement(by: 5)
       end.to change { gauge.get }.by(-5.0)
     end
 

--- a/spec/prometheus/client/gauge_spec.rb
+++ b/spec/prometheus/client/gauge_spec.rb
@@ -1,9 +1,15 @@
 # encoding: UTF-8
 
+require 'prometheus/client'
 require 'prometheus/client/gauge'
 require 'examples/metric_example'
 
 describe Prometheus::Client::Gauge do
+  # Reset the data store
+  before do
+    Prometheus::Client.config.data_store = Prometheus::Client::DataStores::SimpleHash.new
+  end
+
   let(:expected_labels) { [] }
 
   let(:gauge) do
@@ -13,14 +19,14 @@ describe Prometheus::Client::Gauge do
   end
 
   it_behaves_like Prometheus::Client::Metric do
-    let(:type) { NilClass }
+    let(:type) { Float }
   end
 
   describe '#set' do
     it 'sets a metric value' do
       expect do
         gauge.set(42)
-      end.to change { gauge.get }.from(nil).to(42)
+      end.to change { gauge.get }.from(0).to(42)
     end
 
     it 'raises an InvalidLabelSetError if sending unexpected labels' do
@@ -36,7 +42,7 @@ describe Prometheus::Client::Gauge do
         expect do
           expect do
             gauge.set(42, labels: { test: 'value' })
-          end.to change { gauge.get(labels: { test: 'value' }) }.from(nil).to(42)
+          end.to change { gauge.get(labels: { test: 'value' }) }.from(0).to(42)
         end.to_not change { gauge.get(labels: { test: 'other' }) }
       end
     end

--- a/spec/prometheus/client/histogram_spec.rb
+++ b/spec/prometheus/client/histogram_spec.rb
@@ -5,7 +5,7 @@ require 'examples/metric_example'
 
 describe Prometheus::Client::Histogram do
   let(:histogram) do
-    described_class.new(:bar, 'bar description', {}, [2.5, 5, 10])
+    described_class.new(:bar, docstring: 'bar description', buckets: [2.5, 5, 10])
   end
 
   it_behaves_like Prometheus::Client::Metric do
@@ -15,7 +15,7 @@ describe Prometheus::Client::Histogram do
   describe '#initialization' do
     it 'raise error for unsorted buckets' do
       expect do
-        described_class.new(:bar, 'bar description', {}, [5, 2.5, 10])
+        described_class.new(:bar, docstring: 'bar description', buckets: [5, 2.5, 10])
       end.to raise_error ArgumentError
     end
   end
@@ -23,45 +23,46 @@ describe Prometheus::Client::Histogram do
   describe '#observe' do
     it 'records the given value' do
       expect do
-        histogram.observe({}, 5)
+        histogram.observe(5)
       end.to change { histogram.get }
     end
 
     it 'raise error for le labels' do
       expect do
-        histogram.observe({ le: 1 }, 5)
+        histogram.observe(5, labels: { le: 1 })
       end.to raise_error ArgumentError
     end
   end
 
   describe '#get' do
     before do
-      histogram.observe({ foo: 'bar' }, 3)
-      histogram.observe({ foo: 'bar' }, 5.2)
-      histogram.observe({ foo: 'bar' }, 13)
-      histogram.observe({ foo: 'bar' }, 4)
+      histogram.observe(3, labels: { foo: 'bar' })
+      histogram.observe(5.2, labels: { foo: 'bar' })
+      histogram.observe(13, labels: { foo: 'bar' })
+      histogram.observe(4, labels: { foo: 'bar' })
     end
 
     it 'returns a set of buckets values' do
-      expect(histogram.get(foo: 'bar')).to eql(2.5 => 0.0, 5 => 2.0, 10 => 3.0)
+      expect(histogram.get(labels: { foo: 'bar' }))
+        .to eql(2.5 => 0.0, 5 => 2.0, 10 => 3.0)
     end
 
     it 'returns a value which responds to #sum and #total' do
-      value = histogram.get(foo: 'bar')
+      value = histogram.get(labels: { foo: 'bar' })
 
       expect(value.sum).to eql(25.2)
       expect(value.total).to eql(4.0)
     end
 
     it 'uses zero as default value' do
-      expect(histogram.get({})).to eql(2.5 => 0.0, 5 => 0.0, 10 => 0.0)
+      expect(histogram.get).to eql(2.5 => 0.0, 5 => 0.0, 10 => 0.0)
     end
   end
 
   describe '#values' do
     it 'returns a hash of all recorded summaries' do
-      histogram.observe({ status: 'bar' }, 3)
-      histogram.observe({ status: 'foo' }, 6)
+      histogram.observe(3, labels: { status: 'bar' })
+      histogram.observe(6, labels: { status: 'foo' })
 
       expect(histogram.values).to eql(
         { status: 'bar' } => { 2.5 => 0.0, 5 => 1.0, 10 => 1.0 },

--- a/spec/prometheus/client/histogram_spec.rb
+++ b/spec/prometheus/client/histogram_spec.rb
@@ -4,8 +4,13 @@ require 'prometheus/client/histogram'
 require 'examples/metric_example'
 
 describe Prometheus::Client::Histogram do
+  let(:expected_labels) { [] }
+
   let(:histogram) do
-    described_class.new(:bar, docstring: 'bar description', buckets: [2.5, 5, 10])
+    described_class.new(:bar,
+                        docstring: 'bar description',
+                        labels: expected_labels,
+                        buckets: [2.5, 5, 10])
   end
 
   it_behaves_like Prometheus::Client::Metric do
@@ -17,6 +22,12 @@ describe Prometheus::Client::Histogram do
       expect do
         described_class.new(:bar, docstring: 'bar description', buckets: [5, 2.5, 10])
       end.to raise_error ArgumentError
+    end
+
+    it 'raise error for `le` label' do
+      expect do
+        described_class.new(:bar, docstring: 'bar description', labels: [:le])
+      end.to raise_error Prometheus::Client::LabelSetValidator::ReservedLabelError
     end
   end
 
@@ -30,11 +41,31 @@ describe Prometheus::Client::Histogram do
     it 'raise error for le labels' do
       expect do
         histogram.observe(5, labels: { le: 1 })
-      end.to raise_error ArgumentError
+      end.to raise_error Prometheus::Client::LabelSetValidator::ReservedLabelError
+    end
+
+    it 'raises an InvalidLabelSetError if sending unexpected labels' do
+      expect do
+        histogram.observe(5, labels: { foo: 'bar' })
+      end.to raise_error Prometheus::Client::LabelSetValidator::InvalidLabelSetError
+    end
+
+    context "with a an expected label set" do
+      let(:expected_labels) { [:test] }
+
+      it 'observes a value for a given label set' do
+        expect do
+          expect do
+            histogram.observe(5, labels: { test: 'value' })
+          end.to change { histogram.get(labels: { test: 'value' }) }
+        end.to_not change { histogram.get(labels: { test: 'other' }) }
+      end
     end
   end
 
   describe '#get' do
+    let(:expected_labels) { [:foo] }
+
     before do
       histogram.observe(3, labels: { foo: 'bar' })
       histogram.observe(5.2, labels: { foo: 'bar' })
@@ -55,11 +86,13 @@ describe Prometheus::Client::Histogram do
     end
 
     it 'uses zero as default value' do
-      expect(histogram.get).to eql(2.5 => 0.0, 5 => 0.0, 10 => 0.0)
+      expect(histogram.get(labels: { foo: '' })).to eql(2.5 => 0.0, 5 => 0.0, 10 => 0.0)
     end
   end
 
   describe '#values' do
+    let(:expected_labels) { [:status] }
+
     it 'returns a hash of all recorded summaries' do
       histogram.observe(3, labels: { status: 'bar' })
       histogram.observe(6, labels: { status: 'foo' })

--- a/spec/prometheus/client/histogram_spec.rb
+++ b/spec/prometheus/client/histogram_spec.rb
@@ -1,9 +1,15 @@
 # encoding: UTF-8
 
+require 'prometheus/client'
 require 'prometheus/client/histogram'
 require 'examples/metric_example'
 
 describe Prometheus::Client::Histogram do
+  # Reset the data store
+  before do
+    Prometheus::Client.config.data_store = Prometheus::Client::DataStores::SimpleHash.new
+  end
+
   let(:expected_labels) { [] }
 
   let(:histogram) do
@@ -75,18 +81,22 @@ describe Prometheus::Client::Histogram do
 
     it 'returns a set of buckets values' do
       expect(histogram.get(labels: { foo: 'bar' }))
-        .to eql(2.5 => 0.0, 5 => 2.0, 10 => 3.0)
+        .to eql(
+          2.5 => 0.0, 5 => 2.0, 10 => 3.0, "+Inf" => 4.0, "count" => 4.0, "sum" => 25.2
+        )
     end
 
-    it 'returns a value which responds to #sum and #total' do
+    it 'returns a value which includes sum and count' do
       value = histogram.get(labels: { foo: 'bar' })
 
-      expect(value.sum).to eql(25.2)
-      expect(value.total).to eql(4.0)
+      expect(value["sum"]).to eql(25.2)
+      expect(value["count"]).to eql(4.0)
     end
 
     it 'uses zero as default value' do
-      expect(histogram.get(labels: { foo: '' })).to eql(2.5 => 0.0, 5 => 0.0, 10 => 0.0)
+      expect(histogram.get(labels: { foo: '' })).to eql(
+        2.5 => 0.0, 5 => 0.0, 10 => 0.0, "+Inf" => 0.0, "count" => 0.0, "sum" => 0.0
+      )
     end
   end
 
@@ -98,8 +108,8 @@ describe Prometheus::Client::Histogram do
       histogram.observe(6, labels: { status: 'foo' })
 
       expect(histogram.values).to eql(
-        { status: 'bar' } => { 2.5 => 0.0, 5 => 1.0, 10 => 1.0 },
-        { status: 'foo' } => { 2.5 => 0.0, 5 => 0.0, 10 => 1.0 },
+        { status: 'bar' } => { 2.5 => 0.0, 5 => 1.0, 10 => 1.0, "+Inf" => 1.0, "sum" => 3.0 },
+        { status: 'foo' } => { 2.5 => 0.0, 5 => 0.0, 10 => 1.0, "+Inf" => 1.0, "sum" => 6.0 },
       )
     end
   end

--- a/spec/prometheus/client/label_set_validator_spec.rb
+++ b/spec/prometheus/client/label_set_validator_spec.rb
@@ -13,67 +13,67 @@ describe Prometheus::Client::LabelSetValidator do
     end
   end
 
-  describe '#valid?' do
+  describe '#validate_symbols!' do
     it 'returns true for a valid label check' do
-      expect(validator.valid?(version: 'alpha')).to eql(true)
+      expect(validator.validate_symbols!(version: 'alpha')).to eql(true)
     end
 
     it 'raises Invaliddescribed_classError if a label set is not a hash' do
       expect do
-        validator.valid?('invalid')
+        validator.validate_symbols!('invalid')
       end.to raise_exception invalid
     end
 
     it 'raises InvalidLabelError if a label key is not a symbol' do
       expect do
-        validator.valid?('key' => 'value')
+        validator.validate_symbols!('key' => 'value')
       end.to raise_exception(described_class::InvalidLabelError)
     end
 
     it 'raises InvalidLabelError if a label key starts with __' do
       expect do
-        validator.valid?(__reserved__: 'key')
+        validator.validate_symbols!(__reserved__: 'key')
       end.to raise_exception(described_class::ReservedLabelError)
     end
 
     it 'raises ReservedLabelError if a label key is reserved' do
       [:job, :instance].each do |label|
         expect do
-          validator.valid?(label => 'value')
+          validator.validate_symbols!(label => 'value')
         end.to raise_exception(described_class::ReservedLabelError)
       end
     end
   end
 
-  describe '#validate' do
+  describe '#validate_labelset!' do
     let(:expected_labels) { [:method, :code] }
 
     it 'returns a given valid label set' do
       hash = { method: 'get', code: '200' }
 
-      expect(validator.validate(hash)).to eql(hash)
+      expect(validator.validate_labelset!(hash)).to eql(hash)
     end
 
-    it 'raises an exception if a given label set is not `valid?`' do
+    it 'raises an exception if a given label set is not `validate_symbols!`' do
       input = 'broken'
-      expect(validator).to receive(:valid?).with(input).and_raise(invalid)
+      expect(validator).to receive(:validate_symbols!).with(input).and_raise(invalid)
 
-      expect { validator.validate(input) }.to raise_exception(invalid)
+      expect { validator.validate_labelset!(input) }.to raise_exception(invalid)
     end
 
     it 'raises an exception if there are unexpected labels' do
       expect do
-        validator.validate(method: 'get', code: '200', exception: 'NoMethodError')
+        validator.validate_labelset!(method: 'get', code: '200', exception: 'NoMethodError')
       end.to raise_exception(invalid, /keys given: \[:code, :exception, :method\] vs. keys expected: \[:code, :method\]/)
     end
 
     it 'raises an exception if there are missing labels' do
       expect do
-        validator.validate(method: 'get')
+        validator.validate_labelset!(method: 'get')
       end.to raise_exception(invalid, /keys given: \[:method\] vs. keys expected: \[:code, :method\]/)
 
       expect do
-        validator.validate(code: '200')
+        validator.validate_labelset!(code: '200')
       end.to raise_exception(invalid, /keys given: \[:code\] vs. keys expected: \[:code, :method\]/)
     end
   end

--- a/spec/prometheus/client/registry_spec.rb
+++ b/spec/prometheus/client/registry_spec.rb
@@ -68,7 +68,7 @@ describe Prometheus::Client::Registry do
 
   describe '#counter' do
     it 'registers a new counter metric container and returns the counter' do
-      metric = registry.counter(:test, 'test docstring')
+      metric = registry.counter(:test, docstring: 'test docstring')
 
       expect(metric).to be_a(Prometheus::Client::Counter)
     end
@@ -76,7 +76,7 @@ describe Prometheus::Client::Registry do
 
   describe '#gauge' do
     it 'registers a new gauge metric container and returns the gauge' do
-      metric = registry.gauge(:test, 'test docstring')
+      metric = registry.gauge(:test, docstring: 'test docstring')
 
       expect(metric).to be_a(Prometheus::Client::Gauge)
     end
@@ -84,7 +84,7 @@ describe Prometheus::Client::Registry do
 
   describe '#summary' do
     it 'registers a new summary metric container and returns the summary' do
-      metric = registry.summary(:test, 'test docstring')
+      metric = registry.summary(:test, docstring: 'test docstring')
 
       expect(metric).to be_a(Prometheus::Client::Summary)
     end
@@ -92,7 +92,7 @@ describe Prometheus::Client::Registry do
 
   describe '#histogram' do
     it 'registers a new histogram metric container and returns the histogram' do
-      metric = registry.histogram(:test, 'test docstring')
+      metric = registry.histogram(:test, docstring: 'test docstring')
 
       expect(metric).to be_a(Prometheus::Client::Histogram)
     end

--- a/spec/prometheus/client/summary_spec.rb
+++ b/spec/prometheus/client/summary_spec.rb
@@ -4,13 +4,24 @@ require 'prometheus/client/summary'
 require 'examples/metric_example'
 
 describe Prometheus::Client::Summary do
+  let(:expected_labels) { [] }
+
   let(:summary) do
     Prometheus::Client::Summary.new(:bar,
-                                    docstring: 'bar description')
+                                    docstring: 'bar description',
+                                    labels: expected_labels)
   end
 
   it_behaves_like Prometheus::Client::Metric do
     let(:type) { Hash }
+  end
+
+  describe '#initialization' do
+    it 'raise error for `quantile` label' do
+      expect do
+        described_class.new(:bar, docstring: 'bar description', labels: [:quantile])
+      end.to raise_error Prometheus::Client::LabelSetValidator::ReservedLabelError
+    end
   end
 
   describe '#observe' do
@@ -19,9 +30,34 @@ describe Prometheus::Client::Summary do
         summary.observe(5)
       end.to change { summary.get }
     end
+    it 'raise error for quantile labels' do
+      expect do
+        summary.observe(5, labels: { quantile: 1 })
+      end.to raise_error Prometheus::Client::LabelSetValidator::ReservedLabelError
+    end
+
+    it 'raises an InvalidLabelSetError if sending unexpected labels' do
+      expect do
+        summary.observe(5, labels: { foo: 'bar' })
+      end.to raise_error Prometheus::Client::LabelSetValidator::InvalidLabelSetError
+    end
+
+    context "with a an expected label set" do
+      let(:expected_labels) { [:test] }
+
+      it 'observes a value for a given label set' do
+        expect do
+          expect do
+            summary.observe(5, labels: { test: 'value' })
+          end.to change { summary.get(labels: { test: 'value' }) }
+        end.to_not change { summary.get(labels: { test: 'other' }) }
+      end
+    end
   end
 
   describe '#get' do
+    let(:expected_labels) { [:foo] }
+
     before do
       summary.observe(3, labels: { foo: 'bar' })
       summary.observe(5.2, labels: { foo: 'bar' })
@@ -47,6 +83,8 @@ describe Prometheus::Client::Summary do
   end
 
   describe '#values' do
+    let(:expected_labels) { [:status] }
+
     it 'returns a hash of all recorded summaries' do
       summary.observe(3, labels: { status: 'bar' })
       summary.observe(5, labels: { status: 'foo' })

--- a/spec/prometheus/client/summary_spec.rb
+++ b/spec/prometheus/client/summary_spec.rb
@@ -4,7 +4,10 @@ require 'prometheus/client/summary'
 require 'examples/metric_example'
 
 describe Prometheus::Client::Summary do
-  let(:summary) { Prometheus::Client::Summary.new(:bar, 'bar description') }
+  let(:summary) do
+    Prometheus::Client::Summary.new(:bar,
+                                    docstring: 'bar description')
+  end
 
   it_behaves_like Prometheus::Client::Metric do
     let(:type) { Hash }
@@ -13,39 +16,40 @@ describe Prometheus::Client::Summary do
   describe '#observe' do
     it 'records the given value' do
       expect do
-        summary.observe({}, 5)
+        summary.observe(5)
       end.to change { summary.get }
     end
   end
 
   describe '#get' do
     before do
-      summary.observe({ foo: 'bar' }, 3)
-      summary.observe({ foo: 'bar' }, 5.2)
-      summary.observe({ foo: 'bar' }, 13)
-      summary.observe({ foo: 'bar' }, 4)
+      summary.observe(3, labels: { foo: 'bar' })
+      summary.observe(5.2, labels: { foo: 'bar' })
+      summary.observe(13, labels: { foo: 'bar' })
+      summary.observe(4, labels: { foo: 'bar' })
     end
 
     it 'returns a set of quantile values' do
-      expect(summary.get(foo: 'bar')).to eql(0.5 => 4, 0.9 => 5.2, 0.99 => 5.2)
+      expect(summary.get(labels: { foo: 'bar' }))
+        .to eql(0.5 => 4, 0.9 => 5.2, 0.99 => 5.2)
     end
 
     it 'returns a value which responds to #sum and #total' do
-      value = summary.get(foo: 'bar')
+      value = summary.get(labels: { foo: 'bar' })
 
       expect(value.sum).to eql(25.2)
       expect(value.total).to eql(4)
     end
 
     it 'uses nil as default value' do
-      expect(summary.get({})).to eql(0.5 => nil, 0.9 => nil, 0.99 => nil)
+      expect(summary.get).to eql(0.5 => nil, 0.9 => nil, 0.99 => nil)
     end
   end
 
   describe '#values' do
     it 'returns a hash of all recorded summaries' do
-      summary.observe({ status: 'bar' }, 3)
-      summary.observe({ status: 'foo' }, 5)
+      summary.observe(3, labels: { status: 'bar' })
+      summary.observe(5, labels: { status: 'foo' })
 
       expect(summary.values).to eql(
         { status: 'bar' } => { 0.5 => 3, 0.9 => 3, 0.99 => 3 },

--- a/spec/prometheus/client/summary_spec.rb
+++ b/spec/prometheus/client/summary_spec.rb
@@ -1,9 +1,15 @@
 # encoding: UTF-8
 
+require 'prometheus/client'
 require 'prometheus/client/summary'
 require 'examples/metric_example'
 
 describe Prometheus::Client::Summary do
+  # Reset the data store
+  before do
+    Prometheus::Client.config.data_store = Prometheus::Client::DataStores::SimpleHash.new
+  end
+
   let(:expected_labels) { [] }
 
   let(:summary) do
@@ -13,7 +19,7 @@ describe Prometheus::Client::Summary do
   end
 
   it_behaves_like Prometheus::Client::Metric do
-    let(:type) { Prometheus::Client::Summary::Value }
+    let(:type) { Hash }
   end
 
   describe '#initialization' do
@@ -27,10 +33,10 @@ describe Prometheus::Client::Summary do
   describe '#observe' do
     it 'records the given value' do
       expect do
-        expect do
-          summary.observe(5)
-        end.to change { summary.get.sum }.from(0.0).to(5.0)
-      end.to change { summary.get.total }.from(0.0).to(1.0)
+        summary.observe(5)
+      end.to change { summary.get }.
+        from({ "count" => 0.0, "sum" => 0.0 }).
+        to({ "count" => 1.0, "sum" => 5.0 })
     end
 
     it 'raise error for quantile labels' do
@@ -52,8 +58,8 @@ describe Prometheus::Client::Summary do
         expect do
           expect do
             summary.observe(5, labels: { test: 'value' })
-          end.to change { summary.get(labels: { test: 'value' }).total }
-        end.to_not change { summary.get(labels: { test: 'other' }).total }
+          end.to change { summary.get(labels: { test: 'value' })["count"] }
+        end.to_not change { summary.get(labels: { test: 'other' })["count"] }
       end
     end
   end
@@ -69,10 +75,8 @@ describe Prometheus::Client::Summary do
     end
 
     it 'returns a value which responds to #sum and #total' do
-      value = summary.get(labels: { foo: 'bar' })
-
-      expect(value.sum).to eql(25.2)
-      expect(value.total).to eql(4.0)
+      expect(summary.get(labels: { foo: 'bar' })).
+        to eql({ "count" => 4.0, "sum" => 25.2 })
     end
   end
 
@@ -83,8 +87,10 @@ describe Prometheus::Client::Summary do
       summary.observe(3, labels: { status: 'bar' })
       summary.observe(5, labels: { status: 'foo' })
 
-      expect(summary.values[{ status: 'bar' }].sum).to eql(3.0)
-      expect(summary.values[{ status: 'foo' }].sum).to eql(5.0)
+      expect(summary.values).to eql(
+        { status: 'bar' } => { "count" => 1.0, "sum" => 3.0 },
+        { status: 'foo' } => { "count" => 1.0, "sum" => 5.0 },
+      )
     end
   end
 end

--- a/spec/prometheus/middleware/collector_spec.rb
+++ b/spec/prometheus/middleware/collector_spec.rb
@@ -104,6 +104,8 @@ describe Prometheus::Middleware::Collector do
         original_app,
         registry: registry,
         counter_label_builder: lambda do |env, code|
+          next { code: nil, method: nil } if env.empty?
+
           {
             code:   code,
             method: env['REQUEST_METHOD'].downcase,

--- a/spec/prometheus/middleware/collector_spec.rb
+++ b/spec/prometheus/middleware/collector_spec.rb
@@ -41,11 +41,11 @@ describe Prometheus::Middleware::Collector do
 
     metric = :http_server_requests_total
     labels = { method: 'get', path: '/foo', code: '200' }
-    expect(registry.get(metric).get(labels)).to eql(1.0)
+    expect(registry.get(metric).get(labels: labels)).to eql(1.0)
 
     metric = :http_server_request_duration_seconds
     labels = { method: 'get', path: '/foo' }
-    expect(registry.get(metric).get(labels)).to include(0.1 => 0, 0.25 => 1)
+    expect(registry.get(metric).get(labels: labels)).to include(0.1 => 0, 0.25 => 1)
   end
 
   it 'normalizes paths containing numeric IDs by default' do
@@ -55,11 +55,11 @@ describe Prometheus::Middleware::Collector do
 
     metric = :http_server_requests_total
     labels = { method: 'get', path: '/foo/:id/bars', code: '200' }
-    expect(registry.get(metric).get(labels)).to eql(1.0)
+    expect(registry.get(metric).get(labels: labels)).to eql(1.0)
 
     metric = :http_server_request_duration_seconds
     labels = { method: 'get', path: '/foo/:id/bars' }
-    expect(registry.get(metric).get(labels)).to include(0.1 => 0, 0.5 => 1)
+    expect(registry.get(metric).get(labels: labels)).to include(0.1 => 0, 0.5 => 1)
   end
 
   it 'normalizes paths containing UUIDs by default' do
@@ -69,11 +69,11 @@ describe Prometheus::Middleware::Collector do
 
     metric = :http_server_requests_total
     labels = { method: 'get', path: '/foo/:uuid/bars', code: '200' }
-    expect(registry.get(metric).get(labels)).to eql(1.0)
+    expect(registry.get(metric).get(labels: labels)).to eql(1.0)
 
     metric = :http_server_request_duration_seconds
     labels = { method: 'get', path: '/foo/:uuid/bars' }
-    expect(registry.get(metric).get(labels)).to include(0.1 => 0, 0.5 => 1)
+    expect(registry.get(metric).get(labels: labels)).to include(0.1 => 0, 0.5 => 1)
   end
 
   context 'when the app raises an exception' do
@@ -94,7 +94,7 @@ describe Prometheus::Middleware::Collector do
 
       metric = :http_server_exceptions_total
       labels = { exception: 'NoMethodError' }
-      expect(registry.get(metric).get(labels)).to eql(1.0)
+      expect(registry.get(metric).get(labels: labels)).to eql(1.0)
     end
   end
 
@@ -117,7 +117,7 @@ describe Prometheus::Middleware::Collector do
 
       metric = :http_server_requests_total
       labels = { method: 'get', code: '200' }
-      expect(registry.get(metric).get(labels)).to eql(1.0)
+      expect(registry.get(metric).get(labels: labels)).to eql(1.0)
     end
   end
 

--- a/spec/prometheus/middleware/collector_spec.rb
+++ b/spec/prometheus/middleware/collector_spec.rb
@@ -6,6 +6,11 @@ require 'prometheus/middleware/collector'
 describe Prometheus::Middleware::Collector do
   include Rack::Test::Methods
 
+  # Reset the data store
+  before do
+    Prometheus::Client.config.data_store = Prometheus::Client::DataStores::SimpleHash.new
+  end
+
   let(:registry) do
     Prometheus::Client::Registry.new
   end

--- a/spec/prometheus/middleware/exporter_spec.rb
+++ b/spec/prometheus/middleware/exporter_spec.rb
@@ -29,7 +29,7 @@ describe Prometheus::Middleware::Exporter do
 
     shared_examples 'ok' do |headers, fmt|
       it "responds with 200 OK and Content-Type #{fmt::CONTENT_TYPE}" do
-        registry.counter(:foo, 'foo counter').increment({}, 9)
+        registry.counter(:foo, docstring: 'foo counter').increment(by: 9)
 
         get '/metrics', nil, headers
 


### PR DESCRIPTION
This PR does a lot of things. It should really be 10 different PRs, one per commit. That was highly impractical, though.

However, please don't click "Files Changed" on the top-right, that's going to be impossible to digest. I really suggest going through these commits one-by-one

-------------------------------------------

Main things this PR does:
- A few refactorings / improvements here and there
- Add keyword arguments to methods, to be more idiomatic within modern Ruby standards
- Create the concept of Data Stores, separate from the Metrics the user declares, to have a clear interface that allows us to swap different implementations.

All of this is groundwork to allow us to tackle the real issue we want to tackle: [Pre-fork servers](https://github.com/prometheus/client_ruby/issues/9)

We will be working on that, and on other improvements to the Client to bring it closer in line to the [Prometheus Best Practices for Client Libraries](https://prometheus.io/docs/instrumenting/writing_clientlibs/) on subsequent PRs