### PR TITLE
Early return FileMappedDict initialisation when in readonly mode.

### DIFF
--- a/lib/prometheus/client/data_stores/direct_file_store.rb
+++ b/lib/prometheus/client/data_stores/direct_file_store.rb
@@ -196,8 +196,6 @@ module Prometheus
             open_file(filename, readonly)
             @used = @f.read(4).unpack('l')[0] if @capacity > 0
 
-            return if readonly
-
             if @used > 0
               # File already has data. Read the existing values
               with_file_lock do
@@ -215,10 +213,14 @@ module Prometheus
             end
           end
 
-          # Yield (key, value, pos). No locking is performed.
+          # Return a list of key-value pairs
           def all_values
             with_file_lock do
-              read_all_values.map { |k, v, p| [k, v] }
+              @positions.map do |key, pos|
+                @f.seek(pos)
+                value = @f.read(8).unpack('d')[0]
+                [key, value]
+              end
             end
           end
 
@@ -311,5 +313,3 @@ module Prometheus
     end
   end
 end
-
-

--- a/lib/prometheus/client/data_stores/direct_file_store.rb
+++ b/lib/prometheus/client/data_stores/direct_file_store.rb
@@ -198,7 +198,7 @@ module Prometheus
 
             if @used > 0
               # File already has data. Read the existing values
-              with_file_lock { read_all_values }
+              with_file_lock { populate_positions }
             else
               # File is empty. Init the `used` counter, if we're in write mode
               if !readonly
@@ -293,7 +293,7 @@ module Prometheus
           end
 
           # Read position of all keys. No locking is performed.
-          def read_all_values
+          def populate_positions
             @f.seek(8)
             while @f.pos < @used
               padded_len = @f.read(4).unpack('l')[0]

--- a/lib/prometheus/client/data_stores/direct_file_store.rb
+++ b/lib/prometheus/client/data_stores/direct_file_store.rb
@@ -196,6 +196,8 @@ module Prometheus
             open_file(filename, readonly)
             @used = @f.read(4).unpack('l')[0] if @capacity > 0
 
+            return if readonly
+
             if @used > 0
               # File already has data. Read the existing values
               with_file_lock do


### PR DESCRIPTION
This commit is an attempt to address some memory bloat problems we've
recently observed in our production deployment. The commit in here tries to
optimise the read path (metrics export) by reducing the amount of
temporary objects created when reading and aggregating data from metric
files.

The attached synthetic benchmark simulates two concurrent threads that
write and read from a shared `direct_file_store` while memory profiling
is enabled. I observed locally a reduction in peak memory usage (best of 3 runs
in each case):

```
# gc_production_branch_do_not_push
Total allocated: 127.99 MB (2231891 objects)
Total retained:  139.68 kB (609 objects)

# this branch
Total allocated: 85.82 MB (1381432 objects)
Total retained:  139.51 kB (608 objects)
```

I also ran the `data_stores.rb` performance benchmark and it outlines no
change from baseline performance. I'd expect the early return
optimisation to provide some advantages when reading an high number of big
files, but such condition is not reproduced in the benchmark.

---

```rb
# frozen_string_literal: true

require "prometheus/client"
require "prometheus/client/data_stores/direct_file_store"
require "prometheus/client/formats/text"

require "memory_profiler"

Prometheus::Client.config.data_store =
    Prometheus::Client::DataStores::DirectFileStore.new(dir: ".")

report = MemoryProfiler.report(allow_files: "direct_file_store.rb") do
  HISTOGRAM = Prometheus::Client.registry.histogram(
    :histogram_metric,
    docstring: "an histogram",
    buckets: [0.1,0.2,0.3,0.4,0.5,0.6,0.7,0.8,0.9,1],
    labels: %i[label1 label2 label3],
  )

  COUNTER = Prometheus::Client.registry.counter(
    :counter_metric,
    docstring: "a counter",
    labels: %i[label4 label5 label6],
  )

  REGISTRY = Prometheus::Client.registry

  def run
    100.times do
      HISTOGRAM.observe(
        rand(1024),
        labels: {
          label1: "foo" + rand(16).to_s,
          label2: rand(512),
          label3: [:a,"b"].sample,
        },
      )

      COUNTER.increment(
        by: rand(1024),
        labels: {
          label4: "foo" + rand(16).to_s,
          label5: rand(512),
          label6: [:a,"b"].sample,
        },
      )

      Prometheus::Client::Formats::Text.marshal(REGISTRY)
    end
  end

  t1 = Thread.new { run }
  t2 = Thread.new { run }

  t1.join
  t2.join
end

report.pretty_print(scale_bytes: true, detailed_report: true)
```